### PR TITLE
move settings from ignored 'custom' to 'buildout' cfg

### DIFF
--- a/buildout/ncwms2/buildout.cfg
+++ b/buildout/ncwms2/buildout.cfg
@@ -18,6 +18,10 @@ parts =
       ncwms
 
 [settings]
+# deployment
+prefix =  ${environment:HOME}/birdhouse
+user = ${environment:USER}
+etc-user = ${:user}
 # tomcat config
 hostname = localhost
 http-port = 8080

--- a/buildout/ncwms2/buildout.cfg
+++ b/buildout/ncwms2/buildout.cfg
@@ -18,10 +18,6 @@ parts =
       ncwms
 
 [settings]
-# deployment
-prefix =  ${environment:HOME}/birdhouse
-user = ${environment:USER}
-etc-user = ${:user}
 # tomcat config
 hostname = localhost
 http-port = 8080

--- a/docker/ncwms2/buildout.cfg
+++ b/docker/ncwms2/buildout.cfg
@@ -17,6 +17,10 @@ parts =
       ncwms
 
 [settings]
+# deployment
+prefix =  ${environment:HOME}/birdhouse
+user = ${environment:USER}
+etc-user = ${:user}
 # tomcat config
 http-port = 8080
 tomcat-xms = 128m


### PR DESCRIPTION
locally built was working because settings where in 'custom' cfg (in gitignore)
they are moved to 'buildout' cfg instead