### PR TITLE
adjust makefile env variable overwriting same dockerfile envs

### DIFF
--- a/docker/ncwms2/Makefile
+++ b/docker/ncwms2/Makefile
@@ -10,9 +10,9 @@ OS_NAME := $(shell uname -s 2>/dev/null || echo "unknown")
 CPU_ARCH := $(shell uname -m 2>/dev/null || uname -p 2>/dev/null || echo "unknown")
 
 # Anaconda 
-ANACONDA_HOME ?= $(HOME)/anaconda
+ANACONDA_HOME ?= opt/anaconda
 CONDA_ENV := birdhouse
-CONDA_ENVS_DIR ?= $(HOME)/.conda/envs
+CONDA_ENVS_DIR ?= opt/conda/envs
 PREFIX := $(CONDA_ENVS_DIR)/$(CONDA_ENV)
 PYTHON_VERSION_MAJOR := 3
 


### PR DESCRIPTION
The `ANACONDA_HOME` and `CONDA_ENV_DIR` are both defined in `docker/ncwms2/Makefile` and `docker/ncwms2/Dockerfile` with different values, making invalid paths when launching the supervisor from a docker image.

Replace the variable values to match and employ the expected paths.